### PR TITLE
secret key

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -56,6 +56,7 @@ default['graphite']['web']['ldap']['USER_QUERY'] = '(sAMAccountName=%s)'
 default['graphite']['web']['ldap']['SEARCH_BASE'] = ''
 default['graphite']['web']['auth']['REMOTE_USER_AUTH'] = false
 default['graphite']['web']['auth']['LOGIN_URL'] = '/account/login'
+default['graphite']['web']['SECRET_KEY'] = 'UNSAFE_DEFAULT'
 default['graphite']['web']['email']['BACKEND'] = 'django.core.mail.backends.smtp.EmailBackend'
 default['graphite']['web']['email']['HOST'] = 'localhost'
 default['graphite']['web']['email']['PORT'] = '25'

--- a/recipes/web.rb
+++ b/recipes/web.rb
@@ -85,6 +85,7 @@ template "#{docroot}/graphite/local_settings.py" do
             :remote_user_auth => node['graphite']['web']['auth']['REMOTE_USER_AUTH'],
             :login_url => node['graphite']['web']['auth']['LOGIN_URL'],
             :email => node['graphite']['web']['email'])
+            :secret_key => node['graphite']['web']['SECRET_KEY'])
   notifies :reload, graphite_web_service_resource
 end
 

--- a/templates/default/local_settings.py.erb
+++ b/templates/default/local_settings.py.erb
@@ -226,3 +226,5 @@ end.join(', ') %> ]
 # MIDDLEWARE_CLASSES or APPS
 #from graphite.app_settings import *
 
+
+SECRET_KEY = '<%= @SECRET_KEY %>'


### PR DESCRIPTION
Maybe this fixes a stupid warning:

```
[Mon Dec 22 18:29:18.896822 2014] [:error] [pid 27207]   warn('SECRET_KEY is
set to an unsafe default. This should be set in local_settings.py for better
security')
[Mon Dec 22 18:29:19.107412 2014] [:error] [pid 27204]
/opt/graphite/webapp/graphite/settings.py:231: UserWarning: SECRET_KEY is set
to an unsafe default. This should be set in local_settings.py for better
security
```
